### PR TITLE
Add placeholder screens for parent and child flows

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,17 @@
 import 'package:flutter/material.dart';
 
+import 'screens/splash_screen.dart';
+import 'screens/role_selection_screen.dart';
+import 'screens/parent_home_screen.dart';
+import 'screens/child_list_screen.dart';
+import 'screens/parent_destination_map_screen.dart';
+import 'screens/parent_settings_screen.dart';
+import 'screens/child_home_screen.dart';
+import 'screens/child_destination_list_screen.dart';
+import 'screens/child_destination_map_screen.dart';
+import 'screens/child_destination_register_screen.dart';
+import 'screens/child_destination_edit_screen.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -7,104 +19,28 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Mimamori Anshin',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const SplashScreen(),
+      routes: {
+        '/roleSelection': (context) => const RoleSelectionScreen(),
+        '/parentHome': (context) => const ParentHomeScreen(),
+        '/childList': (context) => const ChildListScreen(),
+        '/parentDestinationMap': (context) => const ParentDestinationMapScreen(),
+        '/parentSettings': (context) => const ParentSettingsScreen(),
+        '/childHome': (context) => const ChildHomeScreen(),
+        '/childDestinationList': (context) => const ChildDestinationListScreen(),
+        '/childDestinationMap': (context) => const ChildDestinationMapScreen(),
+        '/childDestinationRegister': (context) => const ChildDestinationRegisterScreen(),
+        '/childDestinationEdit': (context) => const ChildDestinationEditScreen(),
+      },
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}

--- a/lib/screens/child_destination_edit_screen.dart
+++ b/lib/screens/child_destination_edit_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildDestinationEditScreen extends StatelessWidget {
+  const ChildDestinationEditScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Destination'),
+      ),
+      body: const Center(
+        child: Text('Child Destination Edit Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/child_destination_list_screen.dart
+++ b/lib/screens/child_destination_list_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildDestinationListScreen extends StatelessWidget {
+  const ChildDestinationListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Destination List'),
+      ),
+      body: const Center(
+        child: Text('Child Destination List Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/child_destination_map_screen.dart
+++ b/lib/screens/child_destination_map_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildDestinationMapScreen extends StatelessWidget {
+  const ChildDestinationMapScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Child Destination Map'),
+      ),
+      body: const Center(
+        child: Text('Child Destination Map Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/child_destination_register_screen.dart
+++ b/lib/screens/child_destination_register_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildDestinationRegisterScreen extends StatelessWidget {
+  const ChildDestinationRegisterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Register Destination'),
+      ),
+      body: const Center(
+        child: Text('Child Destination Register Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/child_home_screen.dart
+++ b/lib/screens/child_home_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildHomeScreen extends StatelessWidget {
+  const ChildHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Child Home'),
+      ),
+      body: const Center(
+        child: Text('Child Home Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/child_list_screen.dart
+++ b/lib/screens/child_list_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChildListScreen extends StatelessWidget {
+  const ChildListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Child List'),
+      ),
+      body: const Center(
+        child: Text('Child List Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/parent_destination_map_screen.dart
+++ b/lib/screens/parent_destination_map_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ParentDestinationMapScreen extends StatelessWidget {
+  const ParentDestinationMapScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parent Destination Map'),
+      ),
+      body: const Center(
+        child: Text('Parent Destination Map Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/parent_home_screen.dart
+++ b/lib/screens/parent_home_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ParentHomeScreen extends StatelessWidget {
+  const ParentHomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Parent Home'),
+      ),
+      body: const Center(
+        child: Text('Parent Home Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/parent_settings_screen.dart
+++ b/lib/screens/parent_settings_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ParentSettingsScreen extends StatelessWidget {
+  const ParentSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: const Center(
+        child: Text('Parent Settings Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/role_selection_screen.dart
+++ b/lib/screens/role_selection_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class RoleSelectionScreen extends StatelessWidget {
+  const RoleSelectionScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select Role'),
+      ),
+      body: const Center(
+        child: Text('Role Selection Screen'),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Splash Screen'),
+      ),
+    );
+  }
+}
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:mimamori_anshin/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('App starts at Splash Screen', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Splash Screen'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- add splash, role selection, parent and child flow screens
- wire new screens into app routes and starting point
- update widget test for new splash screen

## Testing
- `dart format lib test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689214d4598c83298191d651f1281d49