### PR TITLE
feat: add splash delay and routing

### DIFF
--- a/lib/go_router_provider.dart
+++ b/lib/go_router_provider.dart
@@ -1,0 +1,50 @@
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import 'screens/splash_screen.dart';
+import 'screens/role_selection_screen.dart';
+import 'screens/parent_home_screen.dart';
+import 'screens/child_list_screen.dart';
+import 'screens/parent_destination_map_screen.dart';
+import 'screens/parent_settings_screen.dart';
+import 'screens/child_home_screen.dart';
+import 'screens/child_destination_list_screen.dart';
+import 'screens/child_destination_map_screen.dart';
+import 'screens/child_destination_register_screen.dart';
+import 'screens/child_destination_edit_screen.dart';
+
+final goRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    routes: [
+      GoRoute(path: '/', builder: (context, state) => const SplashScreen()),
+      GoRoute(
+          path: '/roleSelection',
+          builder: (context, state) => const RoleSelectionScreen()),
+      GoRoute(
+          path: '/parentHome',
+          builder: (context, state) => const ParentHomeScreen()),
+      GoRoute(
+          path: '/childList', builder: (context, state) => const ChildListScreen()),
+      GoRoute(
+          path: '/parentDestinationMap',
+          builder: (context, state) => const ParentDestinationMapScreen()),
+      GoRoute(
+          path: '/parentSettings',
+          builder: (context, state) => const ParentSettingsScreen()),
+      GoRoute(
+          path: '/childHome', builder: (context, state) => const ChildHomeScreen()),
+      GoRoute(
+          path: '/childDestinationList',
+          builder: (context, state) => const ChildDestinationListScreen()),
+      GoRoute(
+          path: '/childDestinationMap',
+          builder: (context, state) => const ChildDestinationMapScreen()),
+      GoRoute(
+          path: '/childDestinationRegister',
+          builder: (context, state) => const ChildDestinationRegisterScreen()),
+      GoRoute(
+          path: '/childDestinationEdit',
+          builder: (context, state) => const ChildDestinationEditScreen()),
+    ],
+  );
+});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,45 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
-import 'screens/splash_screen.dart';
-import 'screens/role_selection_screen.dart';
-import 'screens/parent_home_screen.dart';
-import 'screens/child_list_screen.dart';
-import 'screens/parent_destination_map_screen.dart';
-import 'screens/parent_settings_screen.dart';
-import 'screens/child_home_screen.dart';
-import 'screens/child_destination_list_screen.dart';
-import 'screens/child_destination_map_screen.dart';
-import 'screens/child_destination_register_screen.dart';
-import 'screens/child_destination_edit_screen.dart';
+import 'go_router_provider.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(goRouterProvider);
+    return MaterialApp.router(
       title: 'Mimamori Anshin',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const SplashScreen(),
-      routes: {
-        '/roleSelection': (context) => const RoleSelectionScreen(),
-        '/parentHome': (context) => const ParentHomeScreen(),
-        '/childList': (context) => const ChildListScreen(),
-        '/parentDestinationMap': (context) => const ParentDestinationMapScreen(),
-        '/parentSettings': (context) => const ParentSettingsScreen(),
-        '/childHome': (context) => const ChildHomeScreen(),
-        '/childDestinationList': (context) => const ChildDestinationListScreen(),
-        '/childDestinationMap': (context) => const ChildDestinationMapScreen(),
-        '/childDestinationRegister': (context) => const ChildDestinationRegisterScreen(),
-        '/childDestinationEdit': (context) => const ChildDestinationEditScreen(),
-      },
+      routerConfig: router,
     );
   }
 }

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,10 +1,21 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
 
-class SplashScreen extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class SplashScreen extends HookWidget {
   const SplashScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    useEffect(() {
+      final timer = Timer(const Duration(seconds: 2), () {
+        context.go('/roleSelection');
+      });
+      return timer.cancel;
+    }, const []);
+
     return const Scaffold(
       body: Center(
         child: Text('Splash Screen'),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,11 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import 'package:mimamori_anshin/main.dart';
 
 void main() {
-  testWidgets('App starts at Splash Screen', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Splash Screen navigates to Role Selection after delay',
+      (tester) async {
+    await tester.pumpWidget(const ProviderScope(child: MyApp()));
     expect(find.text('Splash Screen'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pumpAndSettle();
+    expect(find.text('Role Selection Screen'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- manage GoRouter through a Riverpod provider
- show splash for 2 seconds then route to role selection using hooks
- update widget test to wrap app in ProviderScope

## Testing
- `fvm flutter test` *(fails: command not found: fvm)*
- `dart pub global activate fvm` *(fails: command not found: dart)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68921a2246a883298c733e235b6cd7de