### PR TITLE
feat: add interactive role selection card

### DIFF
--- a/lib/screens/role_selection_screen.dart
+++ b/lib/screens/role_selection_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/role_selection_card.dart';
+
 class RoleSelectionScreen extends StatelessWidget {
   const RoleSelectionScreen({super.key});
 
@@ -9,8 +11,17 @@ class RoleSelectionScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Select Role'),
       ),
-      body: const Center(
-        child: Text('Role Selection Screen'),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            Text('Role Selection Screen'),
+            SizedBox(height: 24),
+            RoleSelectionCard(label: 'Parent', route: '/parentHome'),
+            SizedBox(height: 16),
+            RoleSelectionCard(label: 'Child', route: '/childHome'),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/role_selection_card.dart
+++ b/lib/widgets/role_selection_card.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class RoleSelectionCard extends StatefulWidget {
+  final String label;
+  final String route;
+
+  const RoleSelectionCard({super.key, required this.label, required this.route});
+
+  @override
+  State<RoleSelectionCard> createState() => _RoleSelectionCardState();
+}
+
+class _RoleSelectionCardState extends State<RoleSelectionCard> {
+  bool _hovered = false;
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final card = Material(
+      elevation: _pressed ? 8 : (_hovered ? 4 : 2),
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => context.go(widget.route),
+        onHighlightChanged: (value) => setState(() => _pressed = value),
+        overlayColor: MaterialStateProperty.resolveWith(
+          (states) {
+            final color = Theme.of(context).colorScheme.primary;
+            if (states.contains(MaterialState.pressed)) {
+              return color.withOpacity(0.1);
+            }
+            if (states.contains(MaterialState.hovered)) {
+              return color.withOpacity(0.05);
+            }
+            return null;
+          },
+        ),
+        highlightColor:
+            Theme.of(context).colorScheme.primary.withOpacity(0.2),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Center(child: Text(widget.label)),
+        ),
+      ),
+    );
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: card,
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement RoleSelectionCard with hover and press effects
- embed RoleSelectionCard widgets in role selection screen

## Testing
- `fvm flutter test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68936181a0708329a11263bcf74b8873