### PR TITLE
feat: centralize app style

### DIFF
--- a/lib/constants/app_style.dart
+++ b/lib/constants/app_style.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const primary = Color(0xFF6200EE);
+  static const background = Colors.white;
+}
+
+class AppFontSizes {
+  static const double large = 24;
+  static const double medium = 16;
+  static const double small = 12;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mimamori_anshin/constants/app_style.dart';
 
 import 'go_router_provider.dart';
 
@@ -16,11 +17,10 @@ class MyApp extends ConsumerWidget {
     return MaterialApp.router(
       title: 'Mimamori Anshin',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
         useMaterial3: true,
       ),
       routerConfig: router,
     );
   }
 }
-

--- a/lib/screens/child_home_screen.dart
+++ b/lib/screens/child_home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mimamori_anshin/constants/app_style.dart';
 
 class ChildHomeScreen extends StatelessWidget {
   const ChildHomeScreen({super.key});
@@ -7,12 +8,17 @@ class ChildHomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Child Home'),
+        title: const Text(
+          'Child Home',
+          style: TextStyle(fontSize: AppFontSizes.large),
+        ),
       ),
       body: const Center(
-        child: Text('Child Home Screen'),
+        child: Text(
+          'Child Home Screen',
+          style: TextStyle(fontSize: AppFontSizes.medium),
+        ),
       ),
     );
   }
 }
-

--- a/lib/screens/role_selection_card.dart
+++ b/lib/screens/role_selection_card.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:mimamori_anshin/constants/app_style.dart';
+
+class RoleSelectionCard extends StatelessWidget {
+  const RoleSelectionCard({super.key, required this.title, required this.onTap});
+
+  final String title;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: AppColors.primary,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Center(
+            child: Text(
+              title,
+              style: const TextStyle(
+                fontSize: AppFontSizes.medium,
+                color: Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/role_selection_screen.dart
+++ b/lib/screens/role_selection_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:mimamori_anshin/constants/app_style.dart';
+import 'role_selection_card.dart';
 
 class RoleSelectionScreen extends StatelessWidget {
   const RoleSelectionScreen({super.key});
@@ -6,13 +8,26 @@ class RoleSelectionScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.background,
       appBar: AppBar(
-        title: const Text('Select Role'),
+        title: const Text(
+          'Select Role',
+          style: TextStyle(fontSize: AppFontSizes.large),
+        ),
       ),
-      body: const Center(
-        child: Text('Role Selection Screen'),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RoleSelectionCard(title: 'Parent', onTap: () {}),
+              const SizedBox(height: 16),
+              RoleSelectionCard(title: 'Child', onTap: () {}),
+            ],
+          ),
+        ),
       ),
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- centralize color and font size constants
- apply shared style to role selection and child home screens
- use primary color constant in app theme

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `dart pub global activate fvm` *(fails: command not found)*
- `fvm flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893613db7e08329a944d44d5c906bf3